### PR TITLE
Lighten visited sidebar links

### DIFF
--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -1,4 +1,4 @@
-<aside class="column one-fourth">
+<aside class="column one-fourth main-sidebar">
   <a href="{{ site.baseurl }}/atom.xml">atom/rss feed</a>
   <hr/>
 <ul>

--- a/assets/std.css
+++ b/assets/std.css
@@ -1647,6 +1647,10 @@ select {
     padding: 0
 }
 
+.main-sidebar ul a:visited {
+    color: #77d277;
+}
+
 @media screen and (max-width: 480px) {
     .branding {
         text-align: center


### PR DESCRIPTION
Visited sidebar links have a brighter color. Tracking blog posts you already read is easier.
Other links are intact.